### PR TITLE
Add STANAG 4609 dataset builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -std=c++11 -Wall -Wextra -pedantic
 
-SRC = main.cpp klv.cpp st0601.cpp
+SRC = main.cpp klv.cpp st0601.cpp st0102.cpp st0903.cpp stanag.cpp
 OBJ = $(SRC:.cpp=.o)
 
 main: $(OBJ)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,23 @@ Les exemples fournis couvrent quelques éléments de télémétrie et de détect
 - `SENSOR_NORTH_VELOCITY`
 - `CORNER_LAT_PT1_FULL`
 - `CORNER_LON_PT1_FULL`
+- `CLASSIFICATION` (ST0102)
+- `CLASSIFICATION_SYSTEM` (ST0102)
+- `VMTI_TARGET_ID` (ST0903)
+- `VMTI_DETECTION_STATUS` (ST0903)
 
 D'autres balises ST0601 numériques comme l'altitude/latitude de plate-forme
 alternative, les hauteurs ellipsoïdales ou les angles d'attitude complets sont
 également disponibles. Les champs nécessitant des ensembles imbriqués ou des
 chaînes de caractères (Tag 66, 70, 73, 74, 81, 94, 95, etc.) restent hors du
 cadre de cet exemple minimaliste.
+
+## Couche STANAG 4609
+
+La fonction `stanag::create_dataset` assemble automatiquement un `KLVSet`
+à partir d'un vecteur de couples UL/valeur. Cela facilite la création d'un
+jeu de données STANAG 4609 à partir des balises enregistrées des normes
+ST0102, ST0601 et ST0903.
 
 ## Références
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,53 +1,55 @@
 #include "klv.h"
 #include "st0601.h"
+#include "st0102.h"
+#include "st0903.h"
+#include "stanag.h"
 #include <iostream>
 #include <iomanip>
+#include <tuple>
+#include <vector>
+#include <string>
 
 int main() {
     auto& reg = KLVRegistry::instance();
     misb::st0601::register_st0601(reg);
+    misb::st0102::register_st0102(reg);
+    misb::st0903::register_st0903(reg);
 
-    KLVLeaf heading(misb::st0601::PLATFORM_HEADING_ANGLE, 90.0);
-    KLVLeaf elevation(misb::st0601::TARGET_LOCATION_ELEVATION, 1000.0);
-    KLVLeaf gateWidth(misb::st0601::TARGET_TRACK_GATE_WIDTH, 256.0);
-    KLVLeaf gateHeight(misb::st0601::TARGET_TRACK_GATE_HEIGHT, 128.0);
-    KLVLeaf gateX(misb::st0601::TARGET_TRACK_GATE_X, 640.0);
-    KLVLeaf gateY(misb::st0601::TARGET_TRACK_GATE_Y, 480.0);
-    KLVLeaf sensorLat(misb::st0601::SENSOR_LATITUDE, 45.0);
-    KLVLeaf sensorLon(misb::st0601::SENSOR_LONGITUDE, -75.0);
-    KLVLeaf hFov(misb::st0601::SENSOR_HORIZONTAL_FOV, 20.0);
-    KLVLeaf vFov(misb::st0601::SENSOR_VERTICAL_FOV, 15.0);
-    KLVLeaf frameLat(misb::st0601::FRAME_CENTER_LATITUDE, 44.999);
-    KLVLeaf frameLon(misb::st0601::FRAME_CENTER_LONGITUDE, -74.999);
-    KLVLeaf frameElev(misb::st0601::FRAME_CENTER_ELEVATION, 1100.0);
-    KLVLeaf offLat1(misb::st0601::OFFSET_CORNER_LAT_PT1, 0.01);
-    KLVLeaf offLon1(misb::st0601::OFFSET_CORNER_LON_PT1, -0.02);
-    KLVLeaf windDir(misb::st0601::WIND_DIRECTION, 270.0);
-    KLVLeaf windSpd(misb::st0601::WIND_SPEED, 10.0);
-    KLVLeaf weaponLoad(misb::st0601::WEAPON_LOAD, 0x1234);
-    KLVLeaf magHeading(misb::st0601::PLATFORM_MAGNETIC_HEADING, 180.0);
-    KLVLeaf northVel(misb::st0601::SENSOR_NORTH_VELOCITY, 30.0);
+    using NamedTag = std::tuple<std::string, UL, double>;
+    std::vector<NamedTag> namedTags = {
+        {"Heading", misb::st0601::PLATFORM_HEADING_ANGLE, 90.0},
+        {"Elevation", misb::st0601::TARGET_LOCATION_ELEVATION, 1000.0},
+        {"Gate width", misb::st0601::TARGET_TRACK_GATE_WIDTH, 256.0},
+        {"Gate height", misb::st0601::TARGET_TRACK_GATE_HEIGHT, 128.0},
+        {"Gate X", misb::st0601::TARGET_TRACK_GATE_X, 640.0},
+        {"Gate Y", misb::st0601::TARGET_TRACK_GATE_Y, 480.0},
+        {"Sensor lat", misb::st0601::SENSOR_LATITUDE, 45.0},
+        {"Sensor lon", misb::st0601::SENSOR_LONGITUDE, -75.0},
+        {"Horizontal FOV", misb::st0601::SENSOR_HORIZONTAL_FOV, 20.0},
+        {"Vertical FOV", misb::st0601::SENSOR_VERTICAL_FOV, 15.0},
+        {"Frame center lat", misb::st0601::FRAME_CENTER_LATITUDE, 44.999},
+        {"Frame center lon", misb::st0601::FRAME_CENTER_LONGITUDE, -74.999},
+        {"Frame center elev", misb::st0601::FRAME_CENTER_ELEVATION, 1100.0},
+        {"Offset corner1 lat", misb::st0601::OFFSET_CORNER_LAT_PT1, 0.01},
+        {"Offset corner1 lon", misb::st0601::OFFSET_CORNER_LON_PT1, -0.02},
+        {"Wind direction", misb::st0601::WIND_DIRECTION, 270.0},
+        {"Wind speed", misb::st0601::WIND_SPEED, 10.0},
+        {"Weapon load", misb::st0601::WEAPON_LOAD, 0x1234},
+        {"Magnetic heading", misb::st0601::PLATFORM_MAGNETIC_HEADING, 180.0},
+        {"Sensor north velocity", misb::st0601::SENSOR_NORTH_VELOCITY, 30.0},
+        {"Classification", misb::st0102::CLASSIFICATION, 2.0},
+        {"Classification system", misb::st0102::CLASSIFICATION_SYSTEM, 1.0},
+        {"Target ID", misb::st0903::VMTI_TARGET_ID, 42.0},
+        {"Detection status", misb::st0903::VMTI_DETECTION_STATUS, 1.0}
+    };
 
-    auto headingBytes = heading.encode();
-    auto elevationBytes = elevation.encode();
-    auto widthBytes = gateWidth.encode();
-    auto heightBytes = gateHeight.encode();
-    auto xBytes = gateX.encode();
-    auto yBytes = gateY.encode();
-    auto sLatBytes = sensorLat.encode();
-    auto sLonBytes = sensorLon.encode();
-    auto hFovBytes = hFov.encode();
-    auto vFovBytes = vFov.encode();
-    auto fLatBytes = frameLat.encode();
-    auto fLonBytes = frameLon.encode();
-    auto fElevBytes = frameElev.encode();
-    auto offLat1Bytes = offLat1.encode();
-    auto offLon1Bytes = offLon1.encode();
-    auto windDirBytes = windDir.encode();
-    auto windSpdBytes = windSpd.encode();
-    auto weaponLoadBytes = weaponLoad.encode();
-    auto magHeadingBytes = magHeading.encode();
-    auto northVelBytes = northVel.encode();
+    std::vector<stanag::TagValue> tags;
+    for (const auto& t : namedTags) {
+        tags.push_back({std::get<1>(t), std::get<2>(t)});
+    }
+
+    auto dataSet = stanag::create_dataset(tags);
+    auto dataSetBytes = dataSet.encode();
 
     auto print = [](const std::vector<uint8_t>& data) {
         for (auto b : data) {
@@ -57,108 +59,16 @@ int main() {
         std::cout << std::dec << '\n';
     };
 
-    std::cout << "Heading bytes: ";
-    print(headingBytes);
-    std::cout << "Elevation bytes: ";
-    print(elevationBytes);
-    std::cout << "Gate width bytes: ";
-    print(widthBytes);
-    std::cout << "Gate height bytes: ";
-    print(heightBytes);
-    std::cout << "Gate X bytes: ";
-    print(xBytes);
-    std::cout << "Gate Y bytes: ";
-    print(yBytes);
-    std::cout << "Sensor lat bytes: ";
-    print(sLatBytes);
-    std::cout << "Sensor lon bytes: ";
-    print(sLonBytes);
-    std::cout << "Horizontal FOV bytes: ";
-    print(hFovBytes);
-    std::cout << "Vertical FOV bytes: ";
-    print(vFovBytes);
-    std::cout << "Frame center lat bytes: ";
-    print(fLatBytes);
-    std::cout << "Frame center lon bytes: ";
-    print(fLonBytes);
-    std::cout << "Frame center elev bytes: ";
-    print(fElevBytes);
-    std::cout << "Offset corner1 lat bytes: ";
-    print(offLat1Bytes);
-    std::cout << "Offset corner1 lon bytes: ";
-    print(offLon1Bytes);
-    std::cout << "Wind direction bytes: ";
-    print(windDirBytes);
-    std::cout << "Wind speed bytes: ";
-    print(windSpdBytes);
-    std::cout << "Weapon load bytes: ";
-    print(weaponLoadBytes);
-    std::cout << "Magnetic heading bytes: ";
-    print(magHeadingBytes);
-    std::cout << "Sensor north velocity bytes: ";
-    print(northVelBytes);
+    std::cout << "STANAG 4609 dataset bytes: ";
+    print(dataSetBytes);
 
-    KLVLeaf decodedHeading(misb::st0601::PLATFORM_HEADING_ANGLE);
-    decodedHeading.decode(headingBytes);
-    KLVLeaf decodedElevation(misb::st0601::TARGET_LOCATION_ELEVATION);
-    decodedElevation.decode(elevationBytes);
-    KLVLeaf decodedWidth(misb::st0601::TARGET_TRACK_GATE_WIDTH);
-    decodedWidth.decode(widthBytes);
-    KLVLeaf decodedHeight(misb::st0601::TARGET_TRACK_GATE_HEIGHT);
-    decodedHeight.decode(heightBytes);
-    KLVLeaf decodedX(misb::st0601::TARGET_TRACK_GATE_X);
-    decodedX.decode(xBytes);
-    KLVLeaf decodedY(misb::st0601::TARGET_TRACK_GATE_Y);
-    decodedY.decode(yBytes);
-    KLVLeaf decodedSLat(misb::st0601::SENSOR_LATITUDE);
-    decodedSLat.decode(sLatBytes);
-    KLVLeaf decodedSLon(misb::st0601::SENSOR_LONGITUDE);
-    decodedSLon.decode(sLonBytes);
-    KLVLeaf decodedHFov(misb::st0601::SENSOR_HORIZONTAL_FOV);
-    decodedHFov.decode(hFovBytes);
-    KLVLeaf decodedVFov(misb::st0601::SENSOR_VERTICAL_FOV);
-    decodedVFov.decode(vFovBytes);
-    KLVLeaf decodedFLat(misb::st0601::FRAME_CENTER_LATITUDE);
-    decodedFLat.decode(fLatBytes);
-    KLVLeaf decodedFLon(misb::st0601::FRAME_CENTER_LONGITUDE);
-    decodedFLon.decode(fLonBytes);
-    KLVLeaf decodedFElev(misb::st0601::FRAME_CENTER_ELEVATION);
-    decodedFElev.decode(fElevBytes);
-    KLVLeaf decodedOffLat1(misb::st0601::OFFSET_CORNER_LAT_PT1);
-    decodedOffLat1.decode(offLat1Bytes);
-    KLVLeaf decodedOffLon1(misb::st0601::OFFSET_CORNER_LON_PT1);
-    decodedOffLon1.decode(offLon1Bytes);
-    KLVLeaf decodedWindDir(misb::st0601::WIND_DIRECTION);
-    decodedWindDir.decode(windDirBytes);
-    KLVLeaf decodedWindSpd(misb::st0601::WIND_SPEED);
-    decodedWindSpd.decode(windSpdBytes);
-    KLVLeaf decodedWeaponLoad(misb::st0601::WEAPON_LOAD);
-    decodedWeaponLoad.decode(weaponLoadBytes);
-    KLVLeaf decodedMagHeading(misb::st0601::PLATFORM_MAGNETIC_HEADING);
-    decodedMagHeading.decode(magHeadingBytes);
-    KLVLeaf decodedNorthVel(misb::st0601::SENSOR_NORTH_VELOCITY);
-    decodedNorthVel.decode(northVelBytes);
-
-    std::cout << "Decoded heading: " << decodedHeading.value() << '\n';
-    std::cout << "Decoded elevation: " << decodedElevation.value() << '\n';
-    std::cout << "Decoded gate width: " << decodedWidth.value() << '\n';
-    std::cout << "Decoded gate height: " << decodedHeight.value() << '\n';
-    std::cout << "Decoded gate X: " << decodedX.value() << '\n';
-    std::cout << "Decoded gate Y: " << decodedY.value() << '\n';
-    std::cout << "Decoded sensor lat: " << decodedSLat.value() << '\n';
-    std::cout << "Decoded sensor lon: " << decodedSLon.value() << '\n';
-    std::cout << "Decoded horizontal FOV: " << decodedHFov.value() << '\n';
-    std::cout << "Decoded vertical FOV: " << decodedVFov.value() << '\n';
-    std::cout << "Decoded frame center lat: " << decodedFLat.value() << '\n';
-    std::cout << "Decoded frame center lon: " << decodedFLon.value() << '\n';
-    std::cout << "Decoded frame center elev: " << decodedFElev.value() << '\n';
-    std::cout << "Decoded offset corner1 lat: " << decodedOffLat1.value() << '\n';
-    std::cout << "Decoded offset corner1 lon: " << decodedOffLon1.value() << '\n';
-    std::cout << "Decoded wind direction: " << decodedWindDir.value() << '\n';
-    std::cout << "Decoded wind speed: " << decodedWindSpd.value() << '\n';
-    std::cout << "Decoded weapon load: " << decodedWeaponLoad.value() << '\n';
-    std::cout << "Decoded magnetic heading: " << decodedMagHeading.value() << '\n';
-    std::cout << "Decoded sensor north velocity: " << decodedNorthVel.value() << '\n';
+    for (const auto& t : namedTags) {
+        KLVLeaf leaf(std::get<1>(t), std::get<2>(t));
+        auto bytes = leaf.encode();
+        KLVLeaf decoded(std::get<1>(t));
+        decoded.decode(bytes);
+        std::cout << "Decoded " << std::get<0>(t) << ": " << decoded.value() << '\n';
+    }
 
     return 0;
 }

--- a/st0102.cpp
+++ b/st0102.cpp
@@ -1,0 +1,38 @@
+#include "st0102.h"
+
+namespace misb {
+namespace st0102 {
+
+// Dummy UL values for demonstration purposes
+const UL CLASSIFICATION        = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x02,0x00,0x00,0x00};
+const UL CLASSIFICATION_SYSTEM = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x02,0x00,0x00,0x01};
+
+void register_st0102(KLVRegistry& reg) {
+    // Classification: enumeration -> uint8
+    reg.register_ul(CLASSIFICATION, {
+        [](double code) {
+            uint8_t raw = static_cast<uint8_t>(code);
+            return std::vector<uint8_t>{raw};
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 1) return 0.0;
+            return static_cast<double>(bytes[0]);
+        }
+    });
+
+    // Classification System: enumeration -> uint8
+    reg.register_ul(CLASSIFICATION_SYSTEM, {
+        [](double code) {
+            uint8_t raw = static_cast<uint8_t>(code);
+            return std::vector<uint8_t>{raw};
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 1) return 0.0;
+            return static_cast<double>(bytes[0]);
+        }
+    });
+}
+
+} // namespace st0102
+} // namespace misb
+

--- a/st0102.h
+++ b/st0102.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "klv.h"
+
+namespace misb {
+namespace st0102 {
+
+// Universal Labels for a subset of MISB ST0102 tags
+extern const UL CLASSIFICATION;
+extern const UL CLASSIFICATION_SYSTEM;
+
+// Register encode/decode lambdas for the above ULs
+void register_st0102(KLVRegistry& reg);
+
+} // namespace st0102
+} // namespace misb
+

--- a/st0903.cpp
+++ b/st0903.cpp
@@ -1,0 +1,42 @@
+#include "st0903.h"
+
+namespace misb {
+namespace st0903 {
+
+// Dummy UL values for demonstration purposes
+const UL VMTI_TARGET_ID        = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x00};
+const UL VMTI_DETECTION_STATUS = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x01};
+
+void register_st0903(KLVRegistry& reg) {
+    // VMTI Target ID: uint16 big-endian
+    reg.register_ul(VMTI_TARGET_ID, {
+        [](double id) {
+            uint16_t raw = static_cast<uint16_t>(id);
+            return std::vector<uint8_t>{
+                static_cast<uint8_t>((raw >> 8) & 0xFF),
+                static_cast<uint8_t>(raw & 0xFF)
+            };
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 2) return 0.0;
+            uint16_t raw = (static_cast<uint16_t>(bytes[0]) << 8) | bytes[1];
+            return static_cast<double>(raw);
+        }
+    });
+
+    // VMTI Detection Status: enumeration -> uint8
+    reg.register_ul(VMTI_DETECTION_STATUS, {
+        [](double status) {
+            uint8_t raw = static_cast<uint8_t>(status);
+            return std::vector<uint8_t>{raw};
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 1) return 0.0;
+            return static_cast<double>(bytes[0]);
+        }
+    });
+}
+
+} // namespace st0903
+} // namespace misb
+

--- a/st0903.h
+++ b/st0903.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "klv.h"
+
+namespace misb {
+namespace st0903 {
+
+// Universal Labels for a subset of MISB ST0903 tags
+extern const UL VMTI_TARGET_ID;
+extern const UL VMTI_DETECTION_STATUS;
+
+// Register encode/decode lambdas for the above ULs
+void register_st0903(KLVRegistry& reg);
+
+} // namespace st0903
+} // namespace misb
+

--- a/stanag.cpp
+++ b/stanag.cpp
@@ -1,0 +1,14 @@
+#include "stanag.h"
+#include <memory>
+
+namespace stanag {
+
+KLVSet create_dataset(const std::vector<TagValue>& tags) {
+    KLVSet set;
+    for (const auto& t : tags) {
+        set.add(std::make_shared<KLVLeaf>(t.ul, t.value));
+    }
+    return set;
+}
+
+} // namespace stanag

--- a/stanag.h
+++ b/stanag.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "klv.h"
+#include <vector>
+
+namespace stanag {
+
+struct TagValue {
+    UL ul;
+    double value;
+};
+
+KLVSet create_dataset(const std::vector<TagValue>& tags);
+
+} // namespace stanag


### PR DESCRIPTION
## Summary
- provide stanag::create_dataset helper to assemble KLV sets from UL/value pairs
- use the new helper in the example to build and encode ST0102, ST0601 and ST0903 tags
- document STANAG layer and update build script

## Testing
- `make clean && make && ./main`


------
https://chatgpt.com/codex/tasks/task_e_68c5ebb9dbc48333bb379c50ad5c6778