### PR TITLE
Add macros and example for building STANAG datasets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ add_library(klv STATIC
     st0102/st0102.cpp
     st0601/st0601.cpp
     st0903/st0903.cpp
+    core/klv.h
+    core/stanag.h
+    st0102/st0102.h
+    st0601/st0601.h
+    st0903/st0903.h
+    core/klv_macros.h
 )
 
 target_include_directories(klv PUBLIC
@@ -24,3 +30,9 @@ add_executable(example
 )
 
 target_link_libraries(example PRIVATE klv)
+
+add_executable(macro_example
+    example/macro_example.cpp
+)
+
+target_link_libraries(macro_example PRIVATE klv)

--- a/core/klv_macros.h
+++ b/core/klv_macros.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "klv.h"
+#include "stanag.h"
+#include <memory>
+
+// Macro to create a stanag::TagValue
+#define KLV_TAG(tag, value) stanag::TagValue{tag, value}
+
+// Macro to create a local KLV dataset from TagValue entries
+#define KLV_LOCAL_DATASET(...) stanag::create_dataset({__VA_ARGS__})
+
+// Macro to add a numeric leaf to an existing dataset
+#define KLV_ADD_LEAF(dataset, tag, value) \
+    dataset.add(std::make_shared<KLVLeaf>(tag, value))
+
+// Macro to add raw bytes to an existing dataset
+#define KLV_ADD_BYTES(dataset, tag, bytes) \
+    dataset.add(std::make_shared<KLVBytes>(tag, bytes))

--- a/example/macro_example.cpp
+++ b/example/macro_example.cpp
@@ -1,0 +1,31 @@
+#include "klv_macros.h"
+#include "st0601.h"
+#include "st0102.h"
+#include "st0903.h"
+#include "stanag.h"
+#include <iostream>
+
+int main() {
+    auto& reg = KLVRegistry::instance();
+    misb::st0601::register_st0601(reg);
+    misb::st0102::register_st0102(reg);
+    misb::st0903::register_st0903(reg);
+
+    KLVSet vmti = KLV_LOCAL_DATASET(
+        KLV_TAG(misb::st0903::VMTI_TARGET_ID, 42.0),
+        KLV_TAG(misb::st0903::VMTI_DETECTION_STATUS, 1.0),
+        KLV_TAG(misb::st0903::VMTI_DETECTION_PROBABILITY, 0.85)
+    );
+
+    KLVSet data = KLV_LOCAL_DATASET(
+        KLV_TAG(misb::st0601::SENSOR_LATITUDE, 45.0),
+        KLV_TAG(misb::st0601::SENSOR_LONGITUDE, -75.0)
+    );
+
+    KLV_ADD_LEAF(data, misb::st0601::PLATFORM_HEADING_ANGLE, 90.0);
+    KLV_ADD_BYTES(data, misb::st0601::VMTI_LOCAL_SET, vmti.encode());
+
+    auto bytes = data.encode();
+    std::cout << "Dataset size: " << bytes.size() << '\n';
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose header files to Qt project and build
- introduce helper macros for creating STANAG datasets
- add example using macros to build UAV detection dataset

## Testing
- `cmake ..`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c6808bf48c833398ed55b60f1b7904