### PR TITLE
Expose complete macro example encoding/decoding

### DIFF
--- a/core/klv.cpp
+++ b/core/klv.cpp
@@ -10,19 +10,20 @@ std::vector<uint8_t> KLVLeaf::encode() const {
     auto data = entry->encoder(value_);
     std::vector<uint8_t> out;
     out.insert(out.end(), ul_.begin(), ul_.end());
-    out.push_back(static_cast<uint8_t>(data.size()));
+    out.push_back(static_cast<uint8_t>((data.size() >> 8) & 0xFF));
+    out.push_back(static_cast<uint8_t>(data.size() & 0xFF));
     out.insert(out.end(), data.begin(), data.end());
     return out;
 }
 
 void KLVLeaf::decode(const std::vector<uint8_t>& bytes) {
-    if (bytes.size() < 17) throw std::runtime_error("Too short");
+    if (bytes.size() < 18) throw std::runtime_error("Too short");
     UL ul;
     std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
     if (ul != ul_) throw std::runtime_error("UL mismatch");
-    size_t len = bytes[16];
-    if (bytes.size() < 17 + len) throw std::runtime_error("Length mismatch");
-    std::vector<uint8_t> data(bytes.begin() + 17, bytes.begin() + 17 + len);
+    size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
+    if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
+    std::vector<uint8_t> data(bytes.begin() + 18, bytes.begin() + 18 + len);
     auto* entry = KLVRegistry::instance().find(ul_);
     if (!entry) throw std::runtime_error("Unknown UL");
     value_ = entry->decoder(data);
@@ -34,19 +35,20 @@ KLVBytes::KLVBytes(const UL& ul, const std::vector<uint8_t>& value)
 std::vector<uint8_t> KLVBytes::encode() const {
     std::vector<uint8_t> out;
     out.insert(out.end(), ul_.begin(), ul_.end());
-    out.push_back(static_cast<uint8_t>(value_.size()));
+    out.push_back(static_cast<uint8_t>((value_.size() >> 8) & 0xFF));
+    out.push_back(static_cast<uint8_t>(value_.size() & 0xFF));
     out.insert(out.end(), value_.begin(), value_.end());
     return out;
 }
 
 void KLVBytes::decode(const std::vector<uint8_t>& bytes) {
-    if (bytes.size() < 17) throw std::runtime_error("Too short");
+    if (bytes.size() < 18) throw std::runtime_error("Too short");
     UL ul;
     std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
     if (ul != ul_) throw std::runtime_error("UL mismatch");
-    size_t len = bytes[16];
-    if (bytes.size() < 17 + len) throw std::runtime_error("Length mismatch");
-    value_.assign(bytes.begin() + 17, bytes.begin() + 17 + len);
+    size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
+    if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
+    value_.assign(bytes.begin() + 18, bytes.begin() + 18 + len);
 }
 
 void KLVSet::add(std::shared_ptr<KLVNode> node) {
@@ -63,7 +65,34 @@ std::vector<uint8_t> KLVSet::encode() const {
 }
 
 void KLVSet::decode(const std::vector<uint8_t>& data) {
-    (void)data; // decoding composite not implemented
+    children_.clear();
+    size_t i = 0;
+    while (i + 18 <= data.size()) {
+        UL ul;
+        std::copy(data.begin() + i, data.begin() + i + 16, ul.begin());
+        i += 16;
+        if (i + 2 > data.size()) break;
+        size_t len = (static_cast<size_t>(data[i]) << 8) | data[i + 1];
+        i += 2;
+        if (i + len > data.size()) break;
+        std::vector<uint8_t> value(data.begin() + i, data.begin() + i + len);
+        i += len;
+
+        const KLVEntry* entry = KLVRegistry::instance().find(ul);
+        if (entry) {
+            std::vector<uint8_t> item;
+            item.insert(item.end(), ul.begin(), ul.end());
+            item.push_back(static_cast<uint8_t>((len >> 8) & 0xFF));
+            item.push_back(static_cast<uint8_t>(len & 0xFF));
+            item.insert(item.end(), value.begin(), value.end());
+            auto leaf = std::make_shared<KLVLeaf>(ul);
+            leaf->decode(item);
+            children_.push_back(leaf);
+        } else {
+            auto bytes = std::make_shared<KLVBytes>(ul, value);
+            children_.push_back(bytes);
+        }
+    }
 }
 
 void KLVRegistry::register_ul(const UL& ul, const KLVEntry& entry) {

--- a/core/klv.h
+++ b/core/klv.h
@@ -46,6 +46,7 @@ public:
     void add(std::shared_ptr<KLVNode> node);
     std::vector<uint8_t> encode() const override;
     void decode(const std::vector<uint8_t>& data) override;
+    const std::vector<std::shared_ptr<KLVNode>>& children() const { return children_; }
 private:
     std::vector<std::shared_ptr<KLVNode>> children_;
 };

--- a/example/macro_example.cpp
+++ b/example/macro_example.cpp
@@ -4,6 +4,15 @@
 #include "st0903.h"
 #include "stanag.h"
 #include <iostream>
+#include <iomanip>
+#include <vector>
+
+struct Detection {
+    double id;
+    double prob;
+    double class_id;
+    double tracker_id;
+};
 
 int main() {
     auto& reg = KLVRegistry::instance();
@@ -11,21 +20,83 @@ int main() {
     misb::st0102::register_st0102(reg);
     misb::st0903::register_st0903(reg);
 
-    KLVSet vmti = KLV_LOCAL_DATASET(
-        KLV_TAG(misb::st0903::VMTI_TARGET_ID, 42.0),
-        KLV_TAG(misb::st0903::VMTI_DETECTION_STATUS, 1.0),
-        KLV_TAG(misb::st0903::VMTI_DETECTION_PROBABILITY, 0.85)
-    );
+    std::vector<Detection> detections = {
+        {1, 0.95, 2, 1001},
+        {2, 0.80, 3, 1002},
+        {3, 0.60, 1, 1003},
+        {4, 0.40, 5, 1004},
+        {5, 0.20, 4, 1005}
+    };
+
+    std::cout << "Input UAV data:" << std::fixed << std::setprecision(2) << '\n';
+    std::cout << "  Sensor Latitude: 45.00\n";
+    std::cout << "  Sensor Longitude: -75.00\n";
+    std::cout << "  Platform Heading: 90.00\n";
+
+    std::cout << "Detections:" << '\n';
+    KLVSet vmti;
+    for (const auto& d : detections) {
+        std::cout << "  ID " << d.id
+                  << " class " << d.class_id
+                  << " tracker " << d.tracker_id
+                  << " prob " << d.prob << '\n';
+        KLV_ADD_LEAF(vmti, misb::st0903::VMTI_TARGET_ID, d.id);
+        KLV_ADD_LEAF(vmti, misb::st0903::VMTI_CLASS_ID, d.class_id);
+        KLV_ADD_LEAF(vmti, misb::st0903::VMTI_TRACKER_ID, d.tracker_id);
+        KLV_ADD_LEAF(vmti, misb::st0903::VMTI_DETECTION_PROBABILITY, d.prob);
+    }
 
     KLVSet data = KLV_LOCAL_DATASET(
         KLV_TAG(misb::st0601::SENSOR_LATITUDE, 45.0),
-        KLV_TAG(misb::st0601::SENSOR_LONGITUDE, -75.0)
+        KLV_TAG(misb::st0601::SENSOR_LONGITUDE, -75.0),
+        KLV_TAG(misb::st0601::PLATFORM_HEADING_ANGLE, 90.0)
     );
-
-    KLV_ADD_LEAF(data, misb::st0601::PLATFORM_HEADING_ANGLE, 90.0);
     KLV_ADD_BYTES(data, misb::st0601::VMTI_LOCAL_SET, vmti.encode());
 
     auto bytes = data.encode();
-    std::cout << "Dataset size: " << bytes.size() << '\n';
+    std::cout << "\nEncoded packet:";
+    for (uint8_t b : bytes) {
+        std::cout << ' ' << std::hex << std::setw(2) << std::setfill('0')
+                  << static_cast<int>(b);
+    }
+    std::cout << std::dec << '\n';
+
+    // Decode
+    KLVSet decoded;
+    decoded.decode(bytes);
+    std::cout << "\nDecoded UAV data:" << '\n';
+    KLVSet vmti_decoded;
+    for (const auto& node : decoded.children()) {
+        if (auto leaf = std::dynamic_pointer_cast<KLVLeaf>(node)) {
+            const UL& ul = leaf->ul();
+            if (ul == misb::st0601::SENSOR_LATITUDE) {
+                std::cout << "  Sensor Latitude: " << leaf->value() << '\n';
+            } else if (ul == misb::st0601::SENSOR_LONGITUDE) {
+                std::cout << "  Sensor Longitude: " << leaf->value() << '\n';
+            } else if (ul == misb::st0601::PLATFORM_HEADING_ANGLE) {
+                std::cout << "  Platform Heading: " << leaf->value() << '\n';
+            }
+        } else if (auto bytesNode = std::dynamic_pointer_cast<KLVBytes>(node)) {
+            if (bytesNode->ul() == misb::st0601::VMTI_LOCAL_SET) {
+                vmti_decoded.decode(bytesNode->value());
+            }
+        }
+    }
+
+    const auto& nodes = vmti_decoded.children();
+    std::cout << "Decoded Detections:" << '\n';
+    for (size_t i = 0; i + 3 < nodes.size(); i += 4) {
+        auto id_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i]);
+        auto class_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i + 1]);
+        auto tracker_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i + 2]);
+        auto prob_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i + 3]);
+        if (id_leaf && class_leaf && tracker_leaf && prob_leaf) {
+            std::cout << "  ID " << id_leaf->value()
+                      << " class " << class_leaf->value()
+                      << " tracker " << tracker_leaf->value()
+                      << " prob " << prob_leaf->value() << '\n';
+        }
+    }
+
     return 0;
 }

--- a/st0903/st0903.cpp
+++ b/st0903/st0903.cpp
@@ -7,6 +7,8 @@ namespace st0903 {
 const UL VMTI_TARGET_ID        = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x00};
 const UL VMTI_DETECTION_STATUS = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x01};
 const UL VMTI_DETECTION_PROBABILITY = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x02};
+const UL VMTI_TRACKER_ID        = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x03};
+const UL VMTI_CLASS_ID          = {0x06,0x0E,0x2B,0x34,0x02,0x0B,0x01,0x01,0x01,0x01,0x01,0x01,0x03,0x00,0x00,0x04};
 
 void register_st0903(KLVRegistry& reg) {
     // VMTI Target ID: uint16 big-endian
@@ -48,6 +50,34 @@ void register_st0903(KLVRegistry& reg) {
         [](const std::vector<uint8_t>& bytes) {
             if (bytes.size() != 1) return 0.0;
             return static_cast<double>(bytes[0]) / 255.0;
+        }
+    });
+
+    // VMTI Tracker ID: uint16 big-endian
+    reg.register_ul(VMTI_TRACKER_ID, {
+        [](double id) {
+            uint16_t raw = static_cast<uint16_t>(id);
+            return std::vector<uint8_t>{
+                static_cast<uint8_t>((raw >> 8) & 0xFF),
+                static_cast<uint8_t>(raw & 0xFF)
+            };
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 2) return 0.0;
+            uint16_t raw = (static_cast<uint16_t>(bytes[0]) << 8) | bytes[1];
+            return static_cast<double>(raw);
+        }
+    });
+
+    // VMTI Class ID: uint8
+    reg.register_ul(VMTI_CLASS_ID, {
+        [](double cls) {
+            uint8_t raw = static_cast<uint8_t>(cls);
+            return std::vector<uint8_t>{raw};
+        },
+        [](const std::vector<uint8_t>& bytes) {
+            if (bytes.size() != 1) return 0.0;
+            return static_cast<double>(bytes[0]);
         }
     });
 }

--- a/st0903/st0903.h
+++ b/st0903/st0903.h
@@ -9,6 +9,8 @@ namespace st0903 {
 extern const UL VMTI_TARGET_ID;
 extern const UL VMTI_DETECTION_STATUS;
 extern const UL VMTI_DETECTION_PROBABILITY;
+extern const UL VMTI_TRACKER_ID;
+extern const UL VMTI_CLASS_ID;
 
 // Register encode/decode lambdas for the above ULs
 void register_st0903(KLVRegistry& reg);


### PR DESCRIPTION
## Summary
- Print UAV fields, full encoded packet, and decoded values in `macro_example`
- Add ST0903 tracker and class tags
- Support 2-byte lengths and composite decoding in core KLV library

## Testing
- `cmake ..`
- `make`
- `./macro_example`

------
https://chatgpt.com/codex/tasks/task_e_68c6825c7ec48333ad8c22cb864941b9