### PR TITLE
Allow nested datasets for STANAG macros

### DIFF
--- a/core/stanag.cpp
+++ b/core/stanag.cpp
@@ -6,7 +6,11 @@ namespace stanag {
 KLVSet create_dataset(const std::vector<TagValue>& tags) {
     KLVSet set;
     for (const auto& t : tags) {
-        set.add(std::make_shared<KLVLeaf>(t.ul, t.value));
+        if (t.set) {
+            set.add(std::make_shared<KLVBytes>(t.ul, t.set->encode()));
+        } else {
+            set.add(std::make_shared<KLVLeaf>(t.ul, t.value));
+        }
     }
     return set;
 }

--- a/core/stanag.h
+++ b/core/stanag.h
@@ -2,12 +2,20 @@
 
 #include "klv.h"
 #include <vector>
+#include <memory>
 
 namespace stanag {
 
 struct TagValue {
     UL ul;
     double value;
+    std::shared_ptr<KLVSet> set;
+
+    TagValue(const UL& u, double v)
+        : ul(u), value(v), set(nullptr) {}
+
+    TagValue(const UL& u, const KLVSet& s)
+        : ul(u), value(0.0), set(std::make_shared<KLVSet>(s)) {}
 };
 
 KLVSet create_dataset(const std::vector<TagValue>& tags);

--- a/example/stanag4609_simple.cpp
+++ b/example/stanag4609_simple.cpp
@@ -1,18 +1,30 @@
 #include "klv_macros.h"
 #include "st0601.h"
+#include "st0903.h"
 #include <iostream>
 #include <iomanip>
+#include <memory>
 
 int main() {
     auto& reg = KLVRegistry::instance();
     misb::st0601::register_st0601(reg);
+    misb::st0903::register_st0903(reg);
 
-    // Build a simple STANAG 4609 packet using nested macros
+    // Build a STANAG 4609 packet mixing UAV telemetry and VMTI detections
     KLVSet packet = STANAG4609_PACKET(
         KLV_ST_ITEM(0601, UNIX_TIMESTAMP, 1700000000.0),
         KLV_ST_ITEM(0601, SENSOR_LATITUDE, 48.8566),
         KLV_ST_ITEM(0601, SENSOR_LONGITUDE, 2.3522),
-        KLV_ST_ITEM(0601, PLATFORM_HEADING_ANGLE, 90.0));
+        KLV_ST_ITEM(0601, PLATFORM_HEADING_ANGLE, 90.0),
+        KLV_ST_DATASET(0601, VMTI_LOCAL_SET,
+            KLV_ST_ITEM(0903, VMTI_TARGET_ID, 1.0),
+            KLV_ST_ITEM(0903, VMTI_DETECTION_STATUS, 1.0),
+            KLV_ST_ITEM(0903, VMTI_DETECTION_PROBABILITY, 0.95),
+            KLV_ST_ITEM(0903, VMTI_TARGET_ID, 2.0),
+            KLV_ST_ITEM(0903, VMTI_DETECTION_STATUS, 1.0),
+            KLV_ST_ITEM(0903, VMTI_DETECTION_PROBABILITY, 0.60)
+        )
+    );
     auto bytes = packet.encode();
 
     std::cout << "Encoded packet:";
@@ -20,7 +32,7 @@ int main() {
         std::cout << ' ' << std::hex << std::setw(2) << std::setfill('0')
                   << static_cast<int>(b);
     }
-    std::cout << std::dec << "\n";
+    std::cout << std::dec << '\n';
 
     // Decode the packet
     KLVSet decoded;
@@ -32,10 +44,27 @@ int main() {
     ST_GET(decoded, 0601, SENSOR_LONGITUDE, lon);
     ST_GET(decoded, 0601, PLATFORM_HEADING_ANGLE, heading);
 
-    std::cout << "Decoded values:\n";
-    std::cout << "  Timestamp: " << ts << "\n";
-    std::cout << "  Latitude : " << lat << "\n";
-    std::cout << "  Longitude: " << lon << "\n";
-    std::cout << "  Heading  : " << heading << "\n";
+    std::cout << "Decoded UAV values:\n";
+    std::cout << "  Timestamp: " << ts << '\n';
+    std::cout << "  Latitude : " << lat << '\n';
+    std::cout << "  Longitude: " << lon << '\n';
+    std::cout << "  Heading  : " << heading << '\n';
+
+    KLVSet vmti_decoded;
+    ST_GET_SET(decoded, 0601, VMTI_LOCAL_SET, vmti_decoded);
+
+    const auto& nodes = vmti_decoded.children();
+    std::cout << "Decoded detections:\n";
+    for (size_t i = 0; i + 2 < nodes.size(); i += 3) {
+        auto id_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i]);
+        auto status_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i + 1]);
+        auto prob_leaf = std::dynamic_pointer_cast<KLVLeaf>(nodes[i + 2]);
+        if (id_leaf && status_leaf && prob_leaf) {
+            std::cout << "  ID " << id_leaf->value()
+                      << " status " << status_leaf->value()
+                      << " prob " << prob_leaf->value() << '\n';
+        }
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- Support nested `KLVSet` values in `TagValue` to build datasets within STANAG packets
- Expand macro helpers to embed and extract sub-datasets
- Provide a richer STANAG 4609 example combining UAV and VMTI information

## Testing
- `cmake ..`
- `cmake --build .`
- `./stanag4609_simple`


------
https://chatgpt.com/codex/tasks/task_e_68c6962408a88333bdf93cec689f96f3