### PR TITLE
Expand STANAG example with macro-based set retrieval

### DIFF
--- a/core/klv_macros.h
+++ b/core/klv_macros.h
@@ -53,3 +53,16 @@
 #define ST_GET_SET(dataset, ST, TAG, out) \
     KLV_GET_SET(dataset, KLV_ST_TAG(ST, TAG), out)
 
+// Convenience macro to decode a nested KLV set given a UL and create a variable
+#define KLV_GET_SET_UL(dataset, ul, name) \
+    KLVSet name; \
+    KLV_GET_SET(dataset, ul, name)
+
+// Convenience macro to decode a nested KLV set given ST and TAG identifiers
+#define ST_GET_SET_UL(dataset, ST, TAG, name) \
+    KLV_GET_SET_UL(dataset, KLV_ST_TAG(ST, TAG), name)
+
+// Iterate over all children of a dataset
+#define KLV_FOR_EACH_CHILD(dataset, child) \
+    for (const auto& child : dataset.children())
+


### PR DESCRIPTION
## Summary
- Provide macros to decode nested KLV sets via UL and iterate over children
- Demonstrate new macros in STANAG 4609 example while decoding multiple detections

## Testing
- `g++ -std=c++17 example/stanag4609_simple.cpp core/*.cpp st0601/*.cpp st0903/*.cpp -Icore -Ist0601 -Ist0903 -o example/stanag4609_simple`
- `./example/stanag4609_simple | tail -n 25`


------
https://chatgpt.com/codex/tasks/task_e_68c69a8f23108333b4b783180fc86012