### PR TITLE
Add tag-based encoding and CRC support for local KLV sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ cadre de cet exemple minimaliste.
 ## Couche STANAG 4609
 
 La fonction `stanag::create_dataset` assemble automatiquement un `KLVSet`
-à partir d'un vecteur de couples UL/valeur. Cela facilite la création d'un
-jeu de données STANAG 4609 à partir des balises enregistrées des normes
-ST0102, ST0601 et ST0903.
+à partir d'un vecteur de couples UL/valeur. Un second argument permet de
+choisir si les éléments sont encodés avec des UL complets (`true`) ou de
+simples tags (`false`). Un troisième paramètre active si besoin l'ajout
+automatique d'un CRC de fin de trame pour les jeux de données locaux.
+Cela facilite la création d'un jeu de données STANAG 4609 à partir des
+balises enregistrées des normes ST0102, ST0601 et ST0903.
 
 ## Références
 

--- a/core/klv_bytes.cpp
+++ b/core/klv_bytes.cpp
@@ -2,24 +2,37 @@
 #include <algorithm>
 #include <stdexcept>
 
-KLVBytes::KLVBytes(const UL& ul, const std::vector<uint8_t>& value)
-    : ul_(ul), value_(value) {}
+KLVBytes::KLVBytes(const UL& ul, const std::vector<uint8_t>& value, bool use_tag)
+    : ul_(ul), value_(value), use_tag_(use_tag) {}
 
 std::vector<uint8_t> KLVBytes::encode() const {
     std::vector<uint8_t> out;
-    out.insert(out.end(), ul_.begin(), ul_.end());
-    out.push_back(static_cast<uint8_t>((value_.size() >> 8) & 0xFF));
-    out.push_back(static_cast<uint8_t>(value_.size() & 0xFF));
+    if (use_tag_) {
+        out.push_back(ul_[15]);
+        out.push_back(static_cast<uint8_t>(value_.size() & 0xFF));
+    } else {
+        out.insert(out.end(), ul_.begin(), ul_.end());
+        out.push_back(static_cast<uint8_t>((value_.size() >> 8) & 0xFF));
+        out.push_back(static_cast<uint8_t>(value_.size() & 0xFF));
+    }
     out.insert(out.end(), value_.begin(), value_.end());
     return out;
 }
 
 void KLVBytes::decode(const std::vector<uint8_t>& bytes) {
-    if (bytes.size() < 18) throw std::runtime_error("Too short");
-    UL ul;
-    std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
-    if (ul != ul_) throw std::runtime_error("UL mismatch");
-    size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
-    if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
-    value_.assign(bytes.begin() + 18, bytes.begin() + 18 + len);
+    if (use_tag_) {
+        if (bytes.size() < 2) throw std::runtime_error("Too short");
+        if (bytes[0] != ul_[15]) throw std::runtime_error("Tag mismatch");
+        size_t len = bytes[1];
+        if (bytes.size() < 2 + len) throw std::runtime_error("Length mismatch");
+        value_.assign(bytes.begin() + 2, bytes.begin() + 2 + len);
+    } else {
+        if (bytes.size() < 18) throw std::runtime_error("Too short");
+        UL ul;
+        std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
+        if (ul != ul_) throw std::runtime_error("UL mismatch");
+        size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
+        if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
+        value_.assign(bytes.begin() + 18, bytes.begin() + 18 + len);
+    }
 }

--- a/core/klv_bytes.h
+++ b/core/klv_bytes.h
@@ -5,7 +5,7 @@
 
 class KLVBytes : public KLVNode {
 public:
-    KLVBytes(const UL& ul, const std::vector<uint8_t>& value = {});
+    KLVBytes(const UL& ul, const std::vector<uint8_t>& value = {}, bool use_tag = false);
     std::vector<uint8_t> encode() const override;
     void decode(const std::vector<uint8_t>& data) override;
     const std::vector<uint8_t>& value() const { return value_; }
@@ -14,4 +14,5 @@ public:
 private:
     UL ul_;
     std::vector<uint8_t> value_;
+    bool use_tag_;
 };

--- a/core/klv_leaf.cpp
+++ b/core/klv_leaf.cpp
@@ -3,29 +3,46 @@
 #include <algorithm>
 #include <stdexcept>
 
-KLVLeaf::KLVLeaf(const UL& ul, double value) : ul_(ul), value_(value) {}
+KLVLeaf::KLVLeaf(const UL& ul, double value, bool use_tag)
+    : ul_(ul), value_(value), use_tag_(use_tag) {}
 
 std::vector<uint8_t> KLVLeaf::encode() const {
     auto* entry = KLVRegistry::instance().find(ul_);
     if (!entry) throw std::runtime_error("Unknown UL");
     auto data = entry->encoder(value_);
     std::vector<uint8_t> out;
-    out.insert(out.end(), ul_.begin(), ul_.end());
-    out.push_back(static_cast<uint8_t>((data.size() >> 8) & 0xFF));
-    out.push_back(static_cast<uint8_t>(data.size() & 0xFF));
+    if (use_tag_) {
+        out.push_back(ul_[15]);
+        out.push_back(static_cast<uint8_t>(data.size() & 0xFF));
+    } else {
+        out.insert(out.end(), ul_.begin(), ul_.end());
+        out.push_back(static_cast<uint8_t>((data.size() >> 8) & 0xFF));
+        out.push_back(static_cast<uint8_t>(data.size() & 0xFF));
+    }
     out.insert(out.end(), data.begin(), data.end());
     return out;
 }
 
 void KLVLeaf::decode(const std::vector<uint8_t>& bytes) {
-    if (bytes.size() < 18) throw std::runtime_error("Too short");
-    UL ul;
-    std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
-    if (ul != ul_) throw std::runtime_error("UL mismatch");
-    size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
-    if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
-    std::vector<uint8_t> data(bytes.begin() + 18, bytes.begin() + 18 + len);
-    auto* entry = KLVRegistry::instance().find(ul_);
-    if (!entry) throw std::runtime_error("Unknown UL");
-    value_ = entry->decoder(data);
+    if (use_tag_) {
+        if (bytes.size() < 2) throw std::runtime_error("Too short");
+        if (bytes[0] != ul_[15]) throw std::runtime_error("Tag mismatch");
+        size_t len = bytes[1];
+        if (bytes.size() < 2 + len) throw std::runtime_error("Length mismatch");
+        std::vector<uint8_t> data(bytes.begin() + 2, bytes.begin() + 2 + len);
+        auto* entry = KLVRegistry::instance().find(ul_);
+        if (!entry) throw std::runtime_error("Unknown UL");
+        value_ = entry->decoder(data);
+    } else {
+        if (bytes.size() < 18) throw std::runtime_error("Too short");
+        UL ul;
+        std::copy(bytes.begin(), bytes.begin() + 16, ul.begin());
+        if (ul != ul_) throw std::runtime_error("UL mismatch");
+        size_t len = (static_cast<size_t>(bytes[16]) << 8) | bytes[17];
+        if (bytes.size() < 18 + len) throw std::runtime_error("Length mismatch");
+        std::vector<uint8_t> data(bytes.begin() + 18, bytes.begin() + 18 + len);
+        auto* entry = KLVRegistry::instance().find(ul_);
+        if (!entry) throw std::runtime_error("Unknown UL");
+        value_ = entry->decoder(data);
+    }
 }

--- a/core/klv_leaf.h
+++ b/core/klv_leaf.h
@@ -5,7 +5,7 @@
 
 class KLVLeaf : public KLVNode {
 public:
-    KLVLeaf(const UL& ul, double value = 0.0);
+    KLVLeaf(const UL& ul, double value = 0.0, bool use_tag = false);
     std::vector<uint8_t> encode() const override;
     void decode(const std::vector<uint8_t>& data) override;
     double value() const { return value_; }
@@ -14,4 +14,5 @@ public:
 private:
     UL ul_;
     double value_;
+    bool use_tag_;
 };

--- a/core/klv_macros.h
+++ b/core/klv_macros.h
@@ -7,7 +7,7 @@
 // Basic tag and set construction
 #define KLV_TAG(tag, value) stanag::TagValue(tag, value)
 #define KLV_SET(...) stanag::create_dataset({__VA_ARGS__})
-#define KLV_LOCAL_DATASET(...) KLV_SET(__VA_ARGS__)
+#define KLV_LOCAL_DATASET(...) stanag::create_dataset({__VA_ARGS__}, false, true)
 #define KLV_DATASET(tag, ...) KLV_TAG(tag, KLV_SET(__VA_ARGS__))
 
 // ST helper to embed nested datasets

--- a/core/klv_set.cpp
+++ b/core/klv_set.cpp
@@ -2,7 +2,28 @@
 #include "klv_leaf.h"
 #include "klv_bytes.h"
 #include "klv_registry.h"
+#include "st_common.h"
 #include <algorithm>
+#include <stdexcept>
+
+namespace {
+uint16_t crc16_ccitt(const std::vector<uint8_t>& data) {
+    uint16_t crc = 0xFFFF;
+    for (uint8_t b : data) {
+        crc ^= static_cast<uint16_t>(b) << 8;
+        for (int i = 0; i < 8; ++i) {
+            if (crc & 0x8000)
+                crc = (crc << 1) ^ 0x1021;
+            else
+                crc <<= 1;
+        }
+    }
+    return crc;
+}
+}
+
+KLVSet::KLVSet(bool use_ul_keys, uint8_t st_id, bool with_crc)
+    : use_ul_keys_(use_ul_keys), st_id_(st_id), with_crc_(with_crc) {}
 
 void KLVSet::add(std::shared_ptr<KLVNode> node) {
     children_.push_back(node);
@@ -14,36 +35,76 @@ std::vector<uint8_t> KLVSet::encode() const {
         auto data = child->encode();
         out.insert(out.end(), data.begin(), data.end());
     }
+    if (!use_ul_keys_ && with_crc_) {
+        uint16_t crc = crc16_ccitt(out);
+        out.push_back(0x01); // CRC tag
+        out.push_back(0x02); // length
+        out.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        out.push_back(static_cast<uint8_t>(crc & 0xFF));
+    }
     return out;
 }
 
 void KLVSet::decode(const std::vector<uint8_t>& data) {
     children_.clear();
     size_t i = 0;
-    while (i + 18 <= data.size()) {
-        UL ul;
-        std::copy(data.begin() + i, data.begin() + i + 16, ul.begin());
-        i += 16;
-        if (i + 2 > data.size()) break;
-        size_t len = (static_cast<size_t>(data[i]) << 8) | data[i + 1];
-        i += 2;
-        if (i + len > data.size()) break;
-        std::vector<uint8_t> value(data.begin() + i, data.begin() + i + len);
-        i += len;
+    while (true) {
+        if (use_ul_keys_) {
+            if (i + 18 > data.size()) break;
+            UL ul;
+            std::copy(data.begin() + i, data.begin() + i + 16, ul.begin());
+            i += 16;
+            if (i + 2 > data.size()) break;
+            size_t len = (static_cast<size_t>(data[i]) << 8) | data[i + 1];
+            i += 2;
+            if (i + len > data.size()) break;
+            std::vector<uint8_t> value(data.begin() + i, data.begin() + i + len);
+            i += len;
 
-        const KLVEntry* entry = KLVRegistry::instance().find(ul);
-        if (entry) {
-            std::vector<uint8_t> item;
-            item.insert(item.end(), ul.begin(), ul.end());
-            item.push_back(static_cast<uint8_t>((len >> 8) & 0xFF));
-            item.push_back(static_cast<uint8_t>(len & 0xFF));
-            item.insert(item.end(), value.begin(), value.end());
-            auto leaf = std::make_shared<KLVLeaf>(ul);
-            leaf->decode(item);
-            children_.push_back(leaf);
+            const KLVEntry* entry = KLVRegistry::instance().find(ul);
+            if (entry) {
+                std::vector<uint8_t> item;
+                item.insert(item.end(), ul.begin(), ul.end());
+                item.push_back(static_cast<uint8_t>((len >> 8) & 0xFF));
+                item.push_back(static_cast<uint8_t>(len & 0xFF));
+                item.insert(item.end(), value.begin(), value.end());
+                auto leaf = std::make_shared<KLVLeaf>(ul);
+                leaf->decode(item);
+                children_.push_back(leaf);
+            } else {
+                auto bytes = std::make_shared<KLVBytes>(ul, value);
+                children_.push_back(bytes);
+            }
         } else {
-            auto bytes = std::make_shared<KLVBytes>(ul, value);
-            children_.push_back(bytes);
+            if (i + 2 > data.size()) break;
+            uint8_t tag = data[i++];
+            if (with_crc_ && tag == 0x01 && i + 3 == data.size()) {
+                size_t len = data[i++];
+                if (len != 2 || i + 2 > data.size()) break;
+                uint16_t crc_val = (static_cast<uint16_t>(data[i]) << 8) | data[i + 1];
+                uint16_t crc_calc = crc16_ccitt(std::vector<uint8_t>(data.begin(), data.begin() + i - 2));
+                if (crc_val != crc_calc) throw std::runtime_error("CRC mismatch");
+                break;
+            }
+            size_t len = data[i++];
+            if (i + len > data.size()) break;
+            UL ul = misb::make_st_ul(st_id_, tag);
+            std::vector<uint8_t> value(data.begin() + i, data.begin() + i + len);
+            i += len;
+
+            const KLVEntry* entry = KLVRegistry::instance().find(ul);
+            if (entry) {
+                std::vector<uint8_t> item;
+                item.push_back(tag);
+                item.push_back(static_cast<uint8_t>(len));
+                item.insert(item.end(), value.begin(), value.end());
+                auto leaf = std::make_shared<KLVLeaf>(ul, 0.0, true);
+                leaf->decode(item);
+                children_.push_back(leaf);
+            } else {
+                auto bytes = std::make_shared<KLVBytes>(ul, value, true);
+                children_.push_back(bytes);
+            }
         }
     }
 }

--- a/core/klv_set.h
+++ b/core/klv_set.h
@@ -5,10 +5,14 @@
 
 class KLVSet : public KLVNode {
 public:
+    KLVSet(bool use_ul_keys = true, uint8_t st_id = 0, bool with_crc = false);
     void add(std::shared_ptr<KLVNode> node);
     std::vector<uint8_t> encode() const override;
     void decode(const std::vector<uint8_t>& data) override;
     const std::vector<std::shared_ptr<KLVNode>>& children() const { return children_; }
 private:
     std::vector<std::shared_ptr<KLVNode>> children_;
+    bool use_ul_keys_;
+    uint8_t st_id_;
+    bool with_crc_;
 };

--- a/core/stanag.cpp
+++ b/core/stanag.cpp
@@ -3,13 +3,15 @@
 
 namespace stanag {
 
-KLVSet create_dataset(const std::vector<TagValue>& tags) {
-    KLVSet set;
+KLVSet create_dataset(const std::vector<TagValue>& tags, bool use_ul, bool with_crc) {
+    uint8_t st_id = 0;
+    if (!tags.empty()) st_id = tags[0].ul[12];
+    KLVSet set(use_ul, st_id, with_crc);
     for (const auto& t : tags) {
         if (t.set) {
-            set.add(std::make_shared<KLVBytes>(t.ul, t.set->encode()));
+            set.add(std::make_shared<KLVBytes>(t.ul, t.set->encode(), !use_ul));
         } else {
-            set.add(std::make_shared<KLVLeaf>(t.ul, t.value));
+            set.add(std::make_shared<KLVLeaf>(t.ul, t.value, !use_ul));
         }
     }
     return set;

--- a/core/stanag.h
+++ b/core/stanag.h
@@ -18,6 +18,6 @@ struct TagValue {
         : ul(u), value(0.0), set(std::make_shared<KLVSet>(s)) {}
 };
 
-KLVSet create_dataset(const std::vector<TagValue>& tags);
+KLVSet create_dataset(const std::vector<TagValue>& tags, bool use_ul = true, bool with_crc = false);
 
 } // namespace stanag

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -74,7 +74,7 @@ int main() {
         for (const auto& t : st0903Tags) {
             vmtiValues.push_back({std::get<1>(t), std::get<2>(t)});
         }
-        KLVSet vmtiSet = stanag::create_dataset(vmtiValues);
+        KLVSet vmtiSet = stanag::create_dataset(vmtiValues, false, true);
 
         KLVSet dataSet;
         for (const auto& t : st0601Tags) {


### PR DESCRIPTION
## Summary
- Allow KLV nodes to encode using tags with 1-byte lengths
- Add optional CRC generation/verification for local KLV sets
- Expose controls for tag/UL encoding via `stanag::create_dataset` and macros

## Testing
- `cmake --build .`
- `./example`


------
https://chatgpt.com/codex/tasks/task_e_68c7db97093483339c7259b26de8a5e8