### PR TITLE
Use BER length for STANAG packets

### DIFF
--- a/core/klv_set.cpp
+++ b/core/klv_set.cpp
@@ -54,9 +54,9 @@ void KLVSet::decode(const std::vector<uint8_t>& data) {
             UL ul;
             std::copy(data.begin() + i, data.begin() + i + 16, ul.begin());
             i += 16;
-            if (i + 2 > data.size()) break;
-            size_t len = (static_cast<size_t>(data[i]) << 8) | data[i + 1];
-            i += 2;
+            size_t len = 0, len_bytes = 0;
+            if (!misb::decode_ber_length(data, i, len, len_bytes)) break;
+            i += len_bytes;
             if (i + len > data.size()) break;
             std::vector<uint8_t> value(data.begin() + i, data.begin() + i + len);
             i += len;
@@ -65,8 +65,8 @@ void KLVSet::decode(const std::vector<uint8_t>& data) {
             if (entry) {
                 std::vector<uint8_t> item;
                 item.insert(item.end(), ul.begin(), ul.end());
-                item.push_back(static_cast<uint8_t>((len >> 8) & 0xFF));
-                item.push_back(static_cast<uint8_t>(len & 0xFF));
+                auto len_vec = misb::encode_ber_length(len);
+                item.insert(item.end(), len_vec.begin(), len_vec.end());
                 item.insert(item.end(), value.begin(), value.end());
                 auto leaf = std::make_shared<KLVLeaf>(ul);
                 leaf->decode(item);

--- a/core/stanag.cpp
+++ b/core/stanag.cpp
@@ -1,4 +1,5 @@
 #include "stanag.h"
+#include "st_common.h"
 #include <memory>
 
 namespace stanag {
@@ -24,8 +25,8 @@ std::vector<uint8_t> create_stanag4609_packet(const std::vector<TagValue>& tags)
     std::vector<uint8_t> out;
     out.insert(out.end(), UAS_DATALINK_LOCAL_SET_UL.begin(),
                UAS_DATALINK_LOCAL_SET_UL.end());
-    out.push_back(static_cast<uint8_t>((payload.size() >> 8) & 0xFF));
-    out.push_back(static_cast<uint8_t>(payload.size() & 0xFF));
+    auto len_bytes = misb::encode_ber_length(payload.size());
+    out.insert(out.end(), len_bytes.begin(), len_bytes.end());
     out.insert(out.end(), payload.begin(), payload.end());
     return out;
 }


### PR DESCRIPTION
## Summary
- Encode STANAG 4609 payload lengths with proper BER encoding
- Support BER lengths across UL-based KLV nodes
- Update examples and tests to parse BER length fields

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c80b1ec0d08333b4233fe4a638fb40