### PR TITLE
Fix BER length for tag-based KLV elements

### DIFF
--- a/core/klv_bytes.cpp
+++ b/core/klv_bytes.cpp
@@ -10,7 +10,8 @@ std::vector<uint8_t> KLVBytes::encode() const {
     std::vector<uint8_t> out;
     if (use_tag_) {
         out.push_back(ul_[15]);
-        out.push_back(static_cast<uint8_t>(value_.size() & 0xFF));
+        auto len_bytes = misb::encode_ber_length(value_.size());
+        out.insert(out.end(), len_bytes.begin(), len_bytes.end());
     } else {
         out.insert(out.end(), ul_.begin(), ul_.end());
         auto len_bytes = misb::encode_ber_length(value_.size());
@@ -24,9 +25,13 @@ void KLVBytes::decode(const std::vector<uint8_t>& bytes) {
     if (use_tag_) {
         if (bytes.size() < 2) throw std::runtime_error("Too short");
         if (bytes[0] != ul_[15]) throw std::runtime_error("Tag mismatch");
-        size_t len = bytes[1];
-        if (bytes.size() < 2 + len) throw std::runtime_error("Length mismatch");
-        value_.assign(bytes.begin() + 2, bytes.begin() + 2 + len);
+        size_t len = 0, len_bytes = 0;
+        if (!misb::decode_ber_length(bytes, 1, len, len_bytes))
+            throw std::runtime_error("Length parse error");
+        if (bytes.size() < 1 + len_bytes + len)
+            throw std::runtime_error("Length mismatch");
+        value_.assign(bytes.begin() + 1 + len_bytes,
+                      bytes.begin() + 1 + len_bytes + len);
     } else {
         if (bytes.size() < 18) throw std::runtime_error("Too short");
         UL ul;

--- a/tests/encode_tests.cpp
+++ b/tests/encode_tests.cpp
@@ -120,5 +120,17 @@ int main() {
     assert(std::fabs(flon - 2.0) < 1e-6);
     assert(std::fabs(ver - 12.0) < 1e-6);
 
+    // Test BER long-form length for tag-based items
+    std::vector<uint8_t> big_vec(130, 0xAB);
+    UL big_ul = misb::make_st_ul(misb::st0601::ST_ID, 0x7F);
+    KLVBytes big_bytes(big_ul, big_vec, true);
+    auto encoded_big = big_bytes.encode();
+    assert(encoded_big[0] == 0x7F);
+    assert(encoded_big[1] == 0x81 && encoded_big[2] == 0x82);
+    assert(encoded_big.size() == 1 + 2 + big_vec.size());
+    KLVBytes big_bytes_dec(big_ul, {}, true);
+    big_bytes_dec.decode(encoded_big);
+    assert(big_bytes_dec.value() == big_vec);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- encode and decode tag-based KLV leaf and bytes values using BER length
- parse BER lengths in local sets using short tags
- add test covering BER long-form length encoding and decoding

## Testing
- `g++ -std=c++17 -Icore -Ist0601 -Ist0102 -Ist0903 tests/encode_tests.cpp core/klv_bytes.cpp core/klv_leaf.cpp core/klv_registry.cpp core/klv_set.cpp core/stanag.cpp st0102/st0102.cpp st0601/st0601.cpp st0903/st0903.cpp -o tests/encode_tests`
- `./tests/encode_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c81aa8e5b48333a60722d4a5785544