### PR TITLE
Add helpers for VMTI series and update macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,18 @@ Les exemples fournis couvrent quelques éléments de télémétrie et de détect
 - `CORNER_LON_PT1_FULL`
 - `CLASSIFICATION` (ST0102)
 - `CLASSIFICATION_SYSTEM` (ST0102)
-- `VMTI_VTARGET_SERIES` et les balises `VTARGET_*` associées pour modéliser une
-  détection VMTI complète (ST0903)
+- `VMTI_VTARGET_SERIES`, `VMTI_ALGORITHM_SERIES`, `VMTI_ONTOLOGY_SERIES` et les
+  balises `VTARGET_*` associées pour modéliser une détection VMTI complète ainsi
+  que ses algorithmes et ontologies (ST0903)
 
 Le jeu de données ST0903 peut être encapsulé dans l'ensemble ST0601 via le
 tag 74 `VMTI_LOCAL_SET`, permettant ainsi de mélanger plusieurs normes dans un
 seul flux KLV.
 
-Le module propose également des aides `encode_vtarget_series` et
-`decode_vtarget_series` pour sérialiser une série de packs vTarget conformes à
-la norme ST 0903 (balise 101) et retrouver facilement les détections codées.
+Le module propose également des aides `encode_vtarget_series`,
+`encode_algorithm_series`, `encode_ontology_series` ainsi que leurs fonctions
+de décodage pour sérialiser les différentes séries ST 0903 (balises 101, 102 et
+103) et retrouver facilement les détections, algorithmes et ontologies codés.
 
 D'autres balises ST0601 numériques comme l'altitude/latitude de plate-forme
 alternative, les hauteurs ellipsoïdales ou les angles d'attitude complets sont

--- a/core/klv_macros.h
+++ b/core/klv_macros.h
@@ -12,6 +12,17 @@
 #define KLV_LOCAL_DATASET(...) stanag::create_dataset({__VA_ARGS__}, false)
 #define KLV_DATASET(tag, ...) KLV_TAG(tag, KLV_SET(__VA_ARGS__))
 
+#define KLV_LOCAL_LEAF(tag, value) std::make_shared<KLVLeaf>(tag, value, true)
+#define KLV_LOCAL_BYTES(tag, bytes) std::make_shared<KLVBytes>(tag, bytes, true)
+
+#define KLV_VTARGET_SERIES(...) misb::st0903::encode_vtarget_series({__VA_ARGS__})
+#define KLV_ALGORITHM_SET(...) \
+    misb::st0903::make_local_set(misb::st0903::ALGORITHM_ST_ID, {__VA_ARGS__})
+#define KLV_ONTOLOGY_SET(...) \
+    misb::st0903::make_local_set(misb::st0903::ONTOLOGY_ST_ID, {__VA_ARGS__})
+#define KLV_ALGORITHM_SERIES(...) misb::st0903::encode_algorithm_series({__VA_ARGS__})
+#define KLV_ONTOLOGY_SERIES(...) misb::st0903::encode_ontology_series({__VA_ARGS__})
+
 // Helper to assemble a VTarget pack with local-tag encoding
 #define KLV_VTARGET_PACK(ID, ...)                                                      \
     misb::st0903::VTargetPack{static_cast<uint64_t>(ID), KLV_LOCAL_DATASET(__VA_ARGS__)}

--- a/example/macro_example.cpp
+++ b/example/macro_example.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
+#include <string>
 #include <cmath>
 #include <limits>
 
@@ -28,6 +29,21 @@ static double extract_value(const KLVSet& set, const UL& ul) {
         }
     }
     return std::numeric_limits<double>::quiet_NaN();
+}
+
+static std::string extract_string(const KLVSet& set, const UL& ul) {
+    for (const auto& node : set.children()) {
+        if (auto bytes = std::dynamic_pointer_cast<KLVBytes>(node)) {
+            if (bytes->ul() == ul) {
+                return std::string(bytes->value().begin(), bytes->value().end());
+            }
+        }
+    }
+    return {};
+}
+
+static std::vector<uint8_t> ascii_bytes(const std::string& text) {
+    return std::vector<uint8_t>(text.begin(), text.end());
 }
 
 int main() {
@@ -59,15 +75,49 @@ int main() {
                   << " centroid (row,col)=(" << d.row << ", " << d.column << ")"
                   << " confidence " << d.confidence
                   << " status " << d.status << '\n';
-        std::vector<stanag::TagValue> entries = {
-            {misb::st0903::VTARGET_CENTROID, compute_pixel(d.row, d.column, frameWidth)},
-            {misb::st0903::VTARGET_CENTROID_ROW, d.row},
-            {misb::st0903::VTARGET_CENTROID_COLUMN, d.column},
-            {misb::st0903::VTARGET_CONFIDENCE_LEVEL, d.confidence},
-            {misb::st0903::VTARGET_DETECTION_STATUS, d.status}
-        };
-        packs.push_back({ d.id, stanag::create_dataset(entries, false) });
+        double algorithmRef = (d.id % 2 == 0) ? 2.0 : 1.0;
+        packs.push_back(KLV_VTARGET_PACK(
+            d.id,
+            KLV_TAG(misb::st0903::VTARGET_CENTROID,
+                    compute_pixel(d.row, d.column, frameWidth)),
+            KLV_TAG(misb::st0903::VTARGET_CENTROID_ROW, d.row),
+            KLV_TAG(misb::st0903::VTARGET_CENTROID_COLUMN, d.column),
+            KLV_TAG(misb::st0903::VTARGET_CONFIDENCE_LEVEL, d.confidence),
+            KLV_TAG(misb::st0903::VTARGET_DETECTION_STATUS, d.status),
+            KLV_TAG(misb::st0903::VTARGET_ALGORITHM_ID, algorithmRef)
+        ));
     }
+
+    auto algorithmSeries = KLV_ALGORITHM_SERIES(
+        KLV_ALGORITHM_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_ID, 1.0),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_NAME, ascii_bytes("MotionNet")),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_VERSION, ascii_bytes("2.1")),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CLASS, 3.0),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CONFIDENCE, 0.95)
+        ),
+        KLV_ALGORITHM_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_ID, 2.0),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_NAME, ascii_bytes("TrackerAI")),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_VERSION, ascii_bytes("1.4")),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CLASS, 4.0),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CONFIDENCE, 0.88)
+        )
+    );
+
+    auto ontologySeries = KLV_ONTOLOGY_SERIES(
+        KLV_ONTOLOGY_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_ID, 101.0),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_URI, ascii_bytes("urn:example:vehicle")),
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_CONFIDENCE, 0.82)
+        ),
+        KLV_ONTOLOGY_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_ID, 202.0),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_URI, ascii_bytes("urn:example:person")),
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_CONFIDENCE, 0.91),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_FAMILY, ascii_bytes("Human"))
+        )
+    );
 
     auto series = misb::st0903::encode_vtarget_series(packs);
 
@@ -80,6 +130,8 @@ int main() {
     vmti.add(std::make_shared<KLVLeaf>(misb::st0903::VMTI_FRAME_WIDTH, frameWidth, true));
     vmti.add(std::make_shared<KLVLeaf>(misb::st0903::VMTI_FRAME_HEIGHT, frameHeight, true));
     vmti.add(std::make_shared<KLVBytes>(misb::st0903::VMTI_VTARGET_SERIES, series, true));
+    vmti.add(std::make_shared<KLVBytes>(misb::st0903::VMTI_ALGORITHM_SERIES, algorithmSeries, true));
+    vmti.add(std::make_shared<KLVBytes>(misb::st0903::VMTI_ONTOLOGY_SERIES, ontologySeries, true));
 
     KLVSet data = KLV_LOCAL_DATASET(
         KLV_TAG(misb::st0601::SENSOR_LATITUDE, 45.0),
@@ -129,11 +181,46 @@ int main() {
                     double col = extract_value(pack.set, misb::st0903::VTARGET_CENTROID_COLUMN);
                     double conf = extract_value(pack.set, misb::st0903::VTARGET_CONFIDENCE_LEVEL);
                     double status = extract_value(pack.set, misb::st0903::VTARGET_DETECTION_STATUS);
+                    double alg = extract_value(pack.set, misb::st0903::VTARGET_ALGORITHM_ID);
                     std::cout << "  ID " << pack.target_id
                               << " centroid " << centroid
                               << " (row,col)=(" << row << ", " << col << ")"
                               << " confidence " << conf
-                              << " status " << status << '\n';
+                              << " status " << status
+                              << " algorithm " << alg << '\n';
+                }
+            } else if (bytesNode->ul() == misb::st0903::VMTI_ALGORITHM_SERIES) {
+                auto algSets = misb::st0903::decode_algorithm_series(bytesNode->value());
+                std::cout << "Decoded algorithms:" << '\n';
+                for (const auto& set : algSets) {
+                    double id = extract_value(set, misb::st0903::ALGORITHM_ID);
+                    double algClass = extract_value(set, misb::st0903::ALGORITHM_CLASS);
+                    double confidence = extract_value(set, misb::st0903::ALGORITHM_CONFIDENCE);
+                    std::string name = extract_string(set, misb::st0903::ALGORITHM_NAME);
+                    std::string version = extract_string(set, misb::st0903::ALGORITHM_VERSION);
+                    std::cout << "  Algorithm " << id
+                              << " (" << name;
+                    if (!version.empty()) {
+                        std::cout << " v" << version;
+                    }
+                    std::cout << ") class " << algClass
+                              << " confidence " << confidence << '\n';
+                }
+            } else if (bytesNode->ul() == misb::st0903::VMTI_ONTOLOGY_SERIES) {
+                auto ontSets = misb::st0903::decode_ontology_series(bytesNode->value());
+                std::cout << "Decoded ontologies:" << '\n';
+                for (const auto& set : ontSets) {
+                    double id = extract_value(set, misb::st0903::ONTOLOGY_ID);
+                    double confidence = extract_value(set, misb::st0903::ONTOLOGY_CONFIDENCE);
+                    std::string uri = extract_string(set, misb::st0903::ONTOLOGY_URI);
+                    std::string family = extract_string(set, misb::st0903::ONTOLOGY_FAMILY);
+                    std::cout << "  Ontology " << id
+                              << " uri " << uri
+                              << " confidence " << confidence;
+                    if (!family.empty()) {
+                        std::cout << " family " << family;
+                    }
+                    std::cout << '\n';
                 }
             }
         }

--- a/st0903/st0903.h
+++ b/st0903/st0903.h
@@ -4,6 +4,7 @@
 #include "st_common.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <vector>
 
 namespace misb {
@@ -11,6 +12,8 @@ namespace st0903 {
 
 constexpr uint8_t ST_ID = 0x03;
 constexpr uint8_t VTARGET_ST_ID = 0x13;
+constexpr uint8_t ALGORITHM_ST_ID = 0x14;
+constexpr uint8_t ONTOLOGY_ST_ID = 0x15;
 
 #define ST0903_LOCAL_SET_TAGS(X) \
     X(VMTI_CHECKSUM, 1) \
@@ -72,6 +75,29 @@ ST0903_VTARGET_TAGS(DEFINE_VTARGET_UL)
 #undef DEFINE_VTARGET_UL
 #undef ST0903_VTARGET_TAGS
 
+#define ST0903_ALGORITHM_TAGS(X) \
+    X(ALGORITHM_ID, 1) \
+    X(ALGORITHM_NAME, 2) \
+    X(ALGORITHM_VERSION, 3) \
+    X(ALGORITHM_CLASS, 4) \
+    X(ALGORITHM_CONFIDENCE, 5)
+
+#define DEFINE_ALGORITHM_UL(name, tag) constexpr UL name = make_st_ul(ALGORITHM_ST_ID, tag);
+ST0903_ALGORITHM_TAGS(DEFINE_ALGORITHM_UL)
+#undef DEFINE_ALGORITHM_UL
+#undef ST0903_ALGORITHM_TAGS
+
+#define ST0903_ONTOLOGY_TAGS(X) \
+    X(ONTOLOGY_ID, 1) \
+    X(ONTOLOGY_URI, 2) \
+    X(ONTOLOGY_CONFIDENCE, 3) \
+    X(ONTOLOGY_FAMILY, 4)
+
+#define DEFINE_ONTOLOGY_UL(name, tag) constexpr UL name = make_st_ul(ONTOLOGY_ST_ID, tag);
+ST0903_ONTOLOGY_TAGS(DEFINE_ONTOLOGY_UL)
+#undef DEFINE_ONTOLOGY_UL
+#undef ST0903_ONTOLOGY_TAGS
+
 struct VTargetPack {
     uint64_t target_id;
     KLVSet set;
@@ -80,9 +106,24 @@ struct VTargetPack {
 // Register encode/decode lambdas for the above ULs
 void register_st0903(KLVRegistry& reg);
 
+// Helper to build a tag-based local set for a given ST0903 sub-set
+KLVSet make_local_set(uint8_t st_id,
+                      std::initializer_list<std::shared_ptr<KLVNode>> nodes);
+
 // Helpers to build and parse the VTarget series payload (tag 101)
 std::vector<uint8_t> encode_vtarget_series(const std::vector<VTargetPack>& packs);
+std::vector<uint8_t> encode_vtarget_series(std::initializer_list<VTargetPack> packs);
 std::vector<VTargetPack> decode_vtarget_series(const std::vector<uint8_t>& bytes);
+
+// Helpers for algorithmSeries (tag 102)
+std::vector<uint8_t> encode_algorithm_series(const std::vector<KLVSet>& sets);
+std::vector<uint8_t> encode_algorithm_series(std::initializer_list<KLVSet> sets);
+std::vector<KLVSet> decode_algorithm_series(const std::vector<uint8_t>& bytes);
+
+// Helpers for ontologySeries (tag 103)
+std::vector<uint8_t> encode_ontology_series(const std::vector<KLVSet>& sets);
+std::vector<uint8_t> encode_ontology_series(std::initializer_list<KLVSet> sets);
+std::vector<KLVSet> decode_ontology_series(const std::vector<uint8_t>& bytes);
 
 } // namespace st0903
 } // namespace misb


### PR DESCRIPTION
## Summary
- add algorithm and ontology series UL constants and helper functions in ST 0903
- extend macro helpers to build local sets and encode series with concise syntax
- update the macro example and tests to cover algorithm/ontology series alongside vTarget packs

## Testing
- cmake --build .
- ./klv_tests


------
https://chatgpt.com/codex/tasks/task_e_68c98e6eae5c8333a699dab1469a8963