### PR TITLE
Provide helpers for centroid pixels and ASCII bytes

### DIFF
--- a/example/stanag4609_simple.cpp
+++ b/example/stanag4609_simple.cpp
@@ -7,10 +7,8 @@
 #include <memory>
 #include <vector>
 #include <limits>
-
-static double pixel_index(double row, double column, double frameWidth) {
-    return column + ((row - 1.0) * frameWidth);
-}
+#include <string>
+#include <cmath>
 
 static double get_value(const KLVSet& set, const UL& ul) {
     for (const auto& node : set.children()) {
@@ -21,12 +19,24 @@ static double get_value(const KLVSet& set, const UL& ul) {
     return std::numeric_limits<double>::quiet_NaN();
 }
 
+static std::string get_string(const KLVSet& set, const UL& ul) {
+    for (const auto& node : set.children()) {
+        if (auto bytes = std::dynamic_pointer_cast<KLVBytes>(node)) {
+            if (bytes->ul() == ul) {
+                return std::string(bytes->value().begin(), bytes->value().end());
+            }
+        }
+    }
+    return {};
+}
+
 int main() {
     auto& reg = KLVRegistry::instance();
     misb::st0601::register_st0601(reg);
     misb::st0903::register_st0903(reg);
 
     const double frameWidth = 1920.0;
+    const double frameHeight = 1080.0;
 
     // Build a VMTI local set with 20 detections
     std::vector<misb::st0903::VTargetPack> packs;
@@ -36,26 +46,64 @@ int main() {
         double col = 200.0 + i * 3.0;
         double confidence = 0.4 + 0.01 * static_cast<double>(i);
         double status = (i % 2 == 0) ? 1.0 : 0.0;
+        double algorithmRef = (i % 2 == 0) ? 2.0 : 1.0;
         packs.push_back(KLV_VTARGET_PACK(
             i,
-            KLV_TAG(misb::st0903::VTARGET_CENTROID, pixel_index(row, col, frameWidth)),
+            KLV_TAG(misb::st0903::VTARGET_CENTROID,
+                    KLV_PIXEL_NUMBER(row, col, frameWidth)),
             KLV_TAG(misb::st0903::VTARGET_CENTROID_ROW, row),
             KLV_TAG(misb::st0903::VTARGET_CENTROID_COLUMN, col),
             KLV_TAG(misb::st0903::VTARGET_CONFIDENCE_LEVEL, confidence),
-            KLV_TAG(misb::st0903::VTARGET_DETECTION_STATUS, status)
+            KLV_TAG(misb::st0903::VTARGET_DETECTION_STATUS, status),
+            KLV_TAG(misb::st0903::VTARGET_ALGORITHM_ID, algorithmRef)
         ));
     }
 
     auto series = misb::st0903::encode_vtarget_series(packs);
+
+    auto algorithmSeries = KLV_ALGORITHM_SERIES(
+        KLV_ALGORITHM_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_ID, 1.0),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_NAME, KLV_ASCII_BYTES("MotionNet")),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_VERSION, KLV_ASCII_BYTES("2.1")),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CLASS, 3.0),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CONFIDENCE, 0.92)
+        ),
+        KLV_ALGORITHM_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_ID, 2.0),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_NAME, KLV_ASCII_BYTES("TrackerAI")),
+            KLV_LOCAL_BYTES(misb::st0903::ALGORITHM_VERSION, KLV_ASCII_BYTES("1.4")),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CLASS, 4.0),
+            KLV_LOCAL_LEAF(misb::st0903::ALGORITHM_CONFIDENCE, 0.88)
+        )
+    );
+
+    auto ontologySeries = KLV_ONTOLOGY_SERIES(
+        KLV_ONTOLOGY_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_ID, 1001.0),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_URI, KLV_ASCII_BYTES("urn:example:vehicle")),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_FAMILY, KLV_ASCII_BYTES("Vehicle")),
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_CONFIDENCE, 0.81)
+        ),
+        KLV_ONTOLOGY_SET(
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_ID, 1002.0),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_URI, KLV_ASCII_BYTES("urn:example:person")),
+            KLV_LOCAL_BYTES(misb::st0903::ONTOLOGY_FAMILY, KLV_ASCII_BYTES("Human")),
+            KLV_LOCAL_LEAF(misb::st0903::ONTOLOGY_CONFIDENCE, 0.93)
+        )
+    );
 
     const double detectionCount = 20.0;
     KLVSet vmti = KLV_LOCAL_DATASET(
         KLV_TAG(misb::st0903::VMTI_LS_VERSION, 6.0),
         KLV_TAG(misb::st0903::VMTI_TOTAL_TARGETS_DETECTED, detectionCount),
         KLV_TAG(misb::st0903::VMTI_NUM_TARGETS_REPORTED, detectionCount),
-        KLV_TAG(misb::st0903::VMTI_FRAME_WIDTH, frameWidth)
+        KLV_TAG(misb::st0903::VMTI_FRAME_WIDTH, frameWidth),
+        KLV_TAG(misb::st0903::VMTI_FRAME_HEIGHT, frameHeight)
     );
     KLV_ADD_BYTES(vmti, misb::st0903::VMTI_VTARGET_SERIES, series);
+    KLV_ADD_BYTES(vmti, misb::st0903::VMTI_ALGORITHM_SERIES, algorithmSeries);
+    KLV_ADD_BYTES(vmti, misb::st0903::VMTI_ONTOLOGY_SERIES, ontologySeries);
 
     // Compose the STANAG 4609 packet (UAS LS version tag added automatically)
     auto packet = STANAG4609_PACKET(
@@ -110,11 +158,47 @@ int main() {
                     double col = get_value(pack.set, misb::st0903::VTARGET_CENTROID_COLUMN);
                     double conf = get_value(pack.set, misb::st0903::VTARGET_CONFIDENCE_LEVEL);
                     double status = get_value(pack.set, misb::st0903::VTARGET_DETECTION_STATUS);
+                    double algorithm = get_value(pack.set, misb::st0903::VTARGET_ALGORITHM_ID);
+                    uint64_t centroidIndex = static_cast<uint64_t>(std::llround(centroid));
                     std::cout << "  ID " << pack.target_id
-                              << " centroid " << centroid
+                              << " centroid " << centroidIndex
                               << " (row,col)=(" << row << ", " << col << ")"
                               << " conf " << conf
-                              << " status " << status << '\n';
+                              << " status " << status
+                              << " algorithm " << algorithm << '\n';
+                }
+            } else if (bytesNode->ul() == misb::st0903::VMTI_ALGORITHM_SERIES) {
+                auto decodedAlgorithms = misb::st0903::decode_algorithm_series(bytesNode->value());
+                std::cout << "Algorithms:\n";
+                for (const auto& algSet : decodedAlgorithms) {
+                    double algId = get_value(algSet, misb::st0903::ALGORITHM_ID);
+                    double algClass = get_value(algSet, misb::st0903::ALGORITHM_CLASS);
+                    double algConfidence = get_value(algSet, misb::st0903::ALGORITHM_CONFIDENCE);
+                    std::string algName = get_string(algSet, misb::st0903::ALGORITHM_NAME);
+                    std::string algVersion = get_string(algSet, misb::st0903::ALGORITHM_VERSION);
+                    std::cout << "  Algorithm " << algId
+                              << " (" << algName;
+                    if (!algVersion.empty()) {
+                        std::cout << " v" << algVersion;
+                    }
+                    std::cout << ") class " << algClass
+                              << " confidence " << algConfidence << '\n';
+                }
+            } else if (bytesNode->ul() == misb::st0903::VMTI_ONTOLOGY_SERIES) {
+                auto decodedOntologies = misb::st0903::decode_ontology_series(bytesNode->value());
+                std::cout << "Ontologies:\n";
+                for (const auto& ontSet : decodedOntologies) {
+                    double ontId = get_value(ontSet, misb::st0903::ONTOLOGY_ID);
+                    double ontConfidence = get_value(ontSet, misb::st0903::ONTOLOGY_CONFIDENCE);
+                    std::string ontUri = get_string(ontSet, misb::st0903::ONTOLOGY_URI);
+                    std::string ontFamily = get_string(ontSet, misb::st0903::ONTOLOGY_FAMILY);
+                    std::cout << "  Ontology " << ontId
+                              << " uri " << ontUri
+                              << " confidence " << ontConfidence;
+                    if (!ontFamily.empty()) {
+                        std::cout << " family " << ontFamily;
+                    }
+                    std::cout << '\n';
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add reusable helpers for ASCII byte conversion and ST0903 centroid pixel numbers and expose them via macros
- update macro_example, stanag4609_simple, and main examples to use the helpers and print centroid indices as raw pixels alongside algorithm/ontology logging

## Testing
- cmake --build build
- ctest --test-dir build
- ./build/macro_example
- ./build/stanag4609_simple

------
https://chatgpt.com/codex/tasks/task_e_68c9976cb7408333bdbd5af0f1b20aab