### PR TITLE
Fix STANAG4609 macro initialization

### DIFF
--- a/core/klv_macros.h
+++ b/core/klv_macros.h
@@ -114,9 +114,11 @@ inline double target_centroid_pixel(double row,
 // Compose a complete STANAG 4609 packet from tag/value pairs
 // Automatically appends the UAS LS version number as the final tag
 // so callers do not need to specify it explicitly.
-#define STANAG4609_PACKET(...) \
-    stanag::create_stanag4609_packet({__VA_ARGS__, \
-                                      KLV_ST_ITEM(0601, UAS_LS_VERSION_NUMBER, 12.0)})
+#define STANAG4609_PACKET(...)                                                    \
+    stanag::create_stanag4609_packet_variadic(__VA_ARGS__,                       \
+                                              KLV_ST_ITEM(0601,                  \
+                                                          UAS_LS_VERSION_NUMBER, \
+                                                          12.0))
 
 // Dataset manipulation helpers
 #define KLV_ADD_LEAF(dataset, tag, value) \

--- a/core/stanag.h
+++ b/core/stanag.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace stanag {
@@ -61,6 +62,15 @@ KLVSet create_dataset(const std::vector<TagValue>& tags, bool use_ul = true);
 
 // Assemble a complete STANAG 4609 packet with the outer UAS Datalink UL
 std::vector<uint8_t> create_stanag4609_packet(const std::vector<TagValue>& tags);
+
+template <typename... TagValues>
+std::vector<uint8_t> create_stanag4609_packet_variadic(TagValues&&... tag_values) {
+    std::vector<TagValue> tags;
+    tags.reserve(sizeof...(tag_values));
+    int unused[] = {(tags.push_back(std::forward<TagValues>(tag_values)), 0)...};
+    (void)unused;
+    return create_stanag4609_packet(tags);
+}
 
 class CompositeBuilder {
 public:


### PR DESCRIPTION
## Summary
- add a variadic helper in `stanag::create_stanag4609_packet_variadic` to build tag vectors without relying on initializer-list conversions
- update the `STANAG4609_PACKET` macro to call the new helper so MSVC can compile the macro example

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d452926b848333a101bf127ec64cec